### PR TITLE
Feature/iat 1340

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -31,7 +31,7 @@ irj:
   systemFullName: "Item Report Job"
 
 tasks:
-  reportSchedule: "0 38 13 * * *"
+  reportSchedule: "0 09 14 * * *"
 
 itembank:
   host: "https://gitlab-dev.smarterbalanced.org"

--- a/application.yml
+++ b/application.yml
@@ -31,14 +31,15 @@ irj:
   systemFullName: "Item Report Job"
 
 tasks:
-  reportSchedule: "0 30 12 * * *"
+  reportSchedule: "0 38 13 * * *"
 
 itembank:
   host: "https://gitlab-dev.smarterbalanced.org"
   accessToken: "${GITLAB_ACCESS_TOKEN}"
   user: "${GITLAB_USER}"
   password: "${GITLAB_PASSWORD}"
-  group: "${GITLAB_GROUP}"
+#  group: "${GITLAB_GROUP}"
+  group: "iat-development"
   localBaseDir: "${HOME}/ItemBankIRJ"
   apiVersion: "/api/v4"
   bankKey: "187"

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ configurations {
 }
 
 dependencies {
-    compile 'org.opentestsystem.ap:ap-common:0.3.15'
+    compile 'org.opentestsystem.ap:ap-common:0.3.16-SNAPSHOT'
 
     compile 'org.springframework.boot:spring-boot-starter-actuator'
     compile 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/org/opentestsystem/ap/irj/config/ApplicationProperties.java
+++ b/src/main/java/org/opentestsystem/ap/irj/config/ApplicationProperties.java
@@ -27,4 +27,6 @@ public class ApplicationProperties {
     private String systemFullName;
 
     private String reportTemplateFolder = "/report_templates";
+
+    private int numberOfThreads = 25;
 }

--- a/src/main/java/org/opentestsystem/ap/irj/config/ReportJobConfig.java
+++ b/src/main/java/org/opentestsystem/ap/irj/config/ReportJobConfig.java
@@ -38,9 +38,7 @@ public class ReportJobConfig {
     @Bean
     public Executor asyncExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(10);
-        executor.setMaxPoolSize(10);
-        executor.setQueueCapacity(500);
+        executor.setCorePoolSize(applicationProperties.getNumberOfThreads());
         executor.setThreadNamePrefix("ReportJob-");
         executor.initialize();
         return executor;

--- a/src/main/java/org/opentestsystem/ap/irj/config/ReportJobConfig.java
+++ b/src/main/java/org/opentestsystem/ap/irj/config/ReportJobConfig.java
@@ -39,6 +39,7 @@ public class ReportJobConfig {
     public Executor asyncExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(applicationProperties.getNumberOfThreads());
+        executor.setMaxPoolSize(applicationProperties.getNumberOfThreads());
         executor.setThreadNamePrefix("ReportJob-");
         executor.initialize();
         return executor;

--- a/src/main/java/org/opentestsystem/ap/irj/model/AbstractAssessmentItemReport.java
+++ b/src/main/java/org/opentestsystem/ap/irj/model/AbstractAssessmentItemReport.java
@@ -51,8 +51,13 @@ public class AbstractAssessmentItemReport<T extends AbstractAssessmentItem> exte
     }
 
     @Override
-    public String getGrade8Or11OnlyAlgebraDescriptor() {
-        return metadata.getGrade8Or11OnlyAlgebraDescriptor();
+    public String getAlgebraDescriptor1() {
+        return metadata.getAlgebraDescriptor1();
+    }
+
+    @Override
+    public String getAlgebraDescriptor2() {
+        return metadata.getAlgebraDescriptor2();
     }
 
     @Override

--- a/src/main/java/org/opentestsystem/ap/irj/model/AbstractItemReport.java
+++ b/src/main/java/org/opentestsystem/ap/irj/model/AbstractItemReport.java
@@ -243,7 +243,12 @@ public class AbstractItemReport<T extends Item> implements ItemReport {
     }
 
     @Override
-    public String getGrade8Or11OnlyAlgebraDescriptor() {
+    public String getAlgebraDescriptor1() {
+        return EMPTY;
+    }
+
+    @Override
+    public String getAlgebraDescriptor2() {
         return EMPTY;
     }
 

--- a/src/main/java/org/opentestsystem/ap/irj/model/ItemReport.java
+++ b/src/main/java/org/opentestsystem/ap/irj/model/ItemReport.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
     "itemPoint", "scoringEngine", "scoringPoints", "accessibilityLanguageComplexity", "length",
     "readabilityFleschKincaid", "readabilityLexile",
     "wordCount", "knowledgeDemands", "languageFeatures", "meaningPurpose", "structure",
-    "grade8Or11OnlyAlgebraDescriptor", "calculator", "copyrightHolder", "copyrightHolderOther",
+    "algebraDescriptor1", "algebraDescriptor2", "calculator", "copyrightHolder", "copyrightHolderOther",
     "testCategory", "performanceTask", "workflowStatusCode",
     "aslRequired", "aslProvided",
     "brailleRequired", "brailleProvided",
@@ -167,8 +167,11 @@ public interface ItemReport {
     @JsonProperty("Structure")
     String getStructure();
 
-    @JsonProperty("Grade 8-or-11-only algebra descriptor")
-    String getGrade8Or11OnlyAlgebraDescriptor();
+    @JsonProperty("Algebra Descriptor 1")
+    public String getAlgebraDescriptor1();
+
+    @JsonProperty("Algebra Descriptor 2")
+    public String getAlgebraDescriptor2();
 
     @JsonProperty("Calculator")
     String getCalculator();

--- a/src/main/java/org/opentestsystem/ap/irj/model/StimulusReport.java
+++ b/src/main/java/org/opentestsystem/ap/irj/model/StimulusReport.java
@@ -62,8 +62,13 @@ public class StimulusReport extends AbstractItemReport<StimItem> {
     }
 
     @Override
-    public String getGrade8Or11OnlyAlgebraDescriptor() {
-        return metadata.getGrade8Or11OnlyAlgebraDescriptor();
+    public String getAlgebraDescriptor1() {
+        return metadata.getAlgebraDescriptor1();
+    }
+
+    @Override
+    public String getAlgebraDescriptor2() {
+        return metadata.getAlgebraDescriptor2();
     }
 
     @Override


### PR DESCRIPTION
… report to change.  The nightly report is primarily listing the metadata properties for each item.  New metadata fields or removing metadata fields means we should look at the nightly report and how it will change.

It was noticed in dev the reports were not being generated.  Not sure what the issue was but the job was running.  It just was not pushing anything to GitLab in the ItemBankReport repository.  

I made a few changes to how the report runs.  It uses a core pool and max pool size of 25, which is now configurable instead of hard coded.  'core' and 'max' need to be the same or else the job will overload GitLab with requests.  I confirmed this does happen when running my tests.  GitLab was overloaded and so certain items were excluded from the report.  They were reported as errors though -> "TransportException: https://gitlab-dev.smarterbalanced.org/iat-development/780.git: authentication not supported" is an example when GitLab is getting overloaded.
