### PR TITLE
Feature/iat 1815

### DIFF
--- a/src/main/java/org/opentestsystem/ap/irj/config/ApplicationProperties.java
+++ b/src/main/java/org/opentestsystem/ap/irj/config/ApplicationProperties.java
@@ -28,5 +28,5 @@ public class ApplicationProperties {
 
     private String reportTemplateFolder = "/report_templates";
 
-    private int numberOfThreads = 25;
+    private int numberOfThreads = 10;
 }

--- a/src/main/java/org/opentestsystem/ap/irj/config/ReportJobConfig.java
+++ b/src/main/java/org/opentestsystem/ap/irj/config/ReportJobConfig.java
@@ -1,7 +1,5 @@
 package org.opentestsystem.ap.irj.config;
 
-import java.util.concurrent.Executor;
-
 import lombok.extern.slf4j.Slf4j;
 import org.opentestsystem.ap.irj.repository.ReportRepository;
 import org.opentestsystem.ap.irj.service.ItemReportManager;
@@ -10,6 +8,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
 
 @Slf4j
 @Configuration

--- a/src/main/java/org/opentestsystem/ap/irj/model/AbstractAssessmentItemReport.java
+++ b/src/main/java/org/opentestsystem/ap/irj/model/AbstractAssessmentItemReport.java
@@ -6,6 +6,9 @@ import org.opentestsystem.ap.common.model.ValidationResult;
 
 import java.util.List;
 
+import static org.opentestsystem.ap.irj.util.ReportUtil.yesNo;
+import static org.opentestsystem.ap.irj.util.ReportUtil.yesNoUndetermined;
+
 public class AbstractAssessmentItemReport<T extends AbstractAssessmentItem> extends AbstractItemReport<T> {
 
     private final ItemMetadata metadata;
@@ -13,6 +16,26 @@ public class AbstractAssessmentItemReport<T extends AbstractAssessmentItem> exte
     public AbstractAssessmentItemReport(final T item, final String reportStatus, final List<ValidationResult> validationResults) {
         super(item, reportStatus, validationResults);
         metadata = item.getCore().getMetadata();
+    }
+
+    @Override
+    public String getAslRequired() {
+        return yesNoUndetermined(getItem().getAsl().getAslRequired());
+    }
+
+    @Override
+    public String getAslProvided() {
+        return yesNo(getItem().getAsl().isAslProvided());
+    }
+
+    @Override
+    public String getTranslationRequired() {
+        return yesNoUndetermined(getItem().getTranslations().getEsp().isRequired());
+    }
+
+    @Override
+    public String getTranslationProvided() {
+        return yesNo(getItem().getTranslations().getEsp().isProvided());
     }
 
     @Override

--- a/src/main/java/org/opentestsystem/ap/irj/model/AbstractItemReport.java
+++ b/src/main/java/org/opentestsystem/ap/irj/model/AbstractItemReport.java
@@ -1,16 +1,19 @@
 package org.opentestsystem.ap.irj.model;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import org.opentestsystem.ap.common.model.Item;
+import org.opentestsystem.ap.common.model.ItemImageResource;
 import org.opentestsystem.ap.common.model.ValidationResult;
 
-import static java.lang.String.valueOf;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.opentestsystem.ap.irj.util.ReportUtil.yesNo;
+import static org.opentestsystem.ap.irj.util.ReportUtil.yesNoUndetermined;
 
 @Data
 public class AbstractItemReport<T extends Item> implements ItemReport {
@@ -279,61 +282,67 @@ public class AbstractItemReport<T extends Item> implements ItemReport {
 
     @Override
     public String getAslRequired() {
-        return getItem().getAsl().getAslRequired();
+        return EMPTY;
     }
 
     @Override
     public String getAslProvided() {
-        return valueOf(getItem().getAsl().isAslProvided());
+        return EMPTY;
     }
 
     @Override
     public String getBrailleRequired() {
-        return getItem().getBraille().getBrailleRequired();
+        return yesNoUndetermined(getItem().getBraille().getBrailleRequired());
     }
 
     @Override
     public String getBrailleProvided() {
-        return valueOf(getItem().getBraille().isBrailleProvided());
+        return yesNo(getItem().getBraille().isBrailleProvided());
     }
 
     @Override
     public String getCcRequired() {
-        return getItem().getCc().getCcRequired();
+        return EMPTY;
     }
 
     @Override
     public String getCcProvided() {
-        return valueOf(getItem().getCc().isCcProvided());
+        return EMPTY;
     }
 
     @Override
     public String getTranslationRequired() {
-//        return getItem().getTranslation().getTranslationRequired();
         return EMPTY;
     }
 
     @Override
     public String getTranslationProvided() {
-//        return getItem().getTranslation().isTranslationProvided();
         return EMPTY;
     }
 
     @Override
     public String getImageProductionFilesProvided() {
-//        return getItem().getImages().;
-        return EMPTY;
+        try {
+            final int numberOfResources = getItem().getImages().getImageResources().size();
+
+            final List<ItemImageResource> resourcesWithProductionFiles = getItem().getImages().getImageResources().stream().
+                    filter(ItemImageResource::isProductionFileProvided).collect(toList());
+
+            return yesNo(numberOfResources == resourcesWithProductionFiles.size());
+        } catch (Exception e) {
+            return yesNo(false);
+        }
     }
 
     @Override
     public String getAudioProductionFilesProvided() {
-//        return getItem().getAudio().;
         return EMPTY;
     }
 
     @Override
     public String getValidationFailureCount() {
-        return valueOf(validationResults.size());
+        return EMPTY;
+//        return valueOf(validationResults.size());
     }
 
     @Override

--- a/src/main/java/org/opentestsystem/ap/irj/model/BaseItemReport.java
+++ b/src/main/java/org/opentestsystem/ap/irj/model/BaseItemReport.java
@@ -1,8 +1,8 @@
 package org.opentestsystem.ap.irj.model;
 
-import java.util.List;
-
 import org.opentestsystem.ap.common.model.ValidationResult;
+
+import java.util.List;
 
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 

--- a/src/main/java/org/opentestsystem/ap/irj/model/EbsrItemReport.java
+++ b/src/main/java/org/opentestsystem/ap/irj/model/EbsrItemReport.java
@@ -1,13 +1,13 @@
 package org.opentestsystem.ap.irj.model;
 
-import java.util.List;
-
 import lombok.Getter;
 import org.opentestsystem.ap.common.model.EbsrItem;
 import org.opentestsystem.ap.common.model.EbsrItemCore;
 import org.opentestsystem.ap.common.model.ItemOption;
 import org.opentestsystem.ap.common.model.ValidationResult;
 import org.opentestsystem.ap.irj.util.ReportUtil;
+
+import java.util.List;
 
 import static java.lang.String.valueOf;
 

--- a/src/main/java/org/opentestsystem/ap/irj/model/EqItemReport.java
+++ b/src/main/java/org/opentestsystem/ap/irj/model/EqItemReport.java
@@ -1,10 +1,10 @@
 package org.opentestsystem.ap.irj.model;
 
-import java.util.List;
-
 import org.opentestsystem.ap.common.model.EqItem;
 import org.opentestsystem.ap.common.model.EqItemCore;
 import org.opentestsystem.ap.common.model.ValidationResult;
+
+import java.util.List;
 
 public class EqItemReport extends AbstractAssessmentItemReport<EqItem> {
 

--- a/src/main/java/org/opentestsystem/ap/irj/model/GiItemReport.java
+++ b/src/main/java/org/opentestsystem/ap/irj/model/GiItemReport.java
@@ -1,7 +1,9 @@
 package org.opentestsystem.ap.irj.model;
 
 import lombok.Getter;
-import org.opentestsystem.ap.common.model.*;
+import org.opentestsystem.ap.common.model.GiItem;
+import org.opentestsystem.ap.common.model.GiItemCore;
+import org.opentestsystem.ap.common.model.ValidationResult;
 import org.opentestsystem.ap.irj.util.ReportUtil;
 
 import java.util.List;

--- a/src/main/java/org/opentestsystem/ap/irj/model/HtqsItemReport.java
+++ b/src/main/java/org/opentestsystem/ap/irj/model/HtqsItemReport.java
@@ -1,7 +1,10 @@
 package org.opentestsystem.ap.irj.model;
 
 import lombok.Getter;
-import org.opentestsystem.ap.common.model.*;
+import org.opentestsystem.ap.common.model.HtqSelectable;
+import org.opentestsystem.ap.common.model.HtqsItem;
+import org.opentestsystem.ap.common.model.HtqsItemCore;
+import org.opentestsystem.ap.common.model.ValidationResult;
 import org.opentestsystem.ap.irj.util.ReportUtil;
 
 import java.util.List;

--- a/src/main/java/org/opentestsystem/ap/irj/model/LoadResult.java
+++ b/src/main/java/org/opentestsystem/ap/irj/model/LoadResult.java
@@ -1,10 +1,10 @@
 package org.opentestsystem.ap.irj.model;
 
-import java.util.List;
-
 import lombok.Data;
 import org.opentestsystem.ap.common.model.Item;
 import org.opentestsystem.ap.common.model.ValidationResult;
+
+import java.util.List;
 
 @Data
 public class LoadResult {

--- a/src/main/java/org/opentestsystem/ap/irj/model/McItemReport.java
+++ b/src/main/java/org/opentestsystem/ap/irj/model/McItemReport.java
@@ -1,13 +1,13 @@
 package org.opentestsystem.ap.irj.model;
 
-import java.util.List;
-
 import lombok.Getter;
 import org.opentestsystem.ap.common.model.ItemOption;
 import org.opentestsystem.ap.common.model.McItem;
 import org.opentestsystem.ap.common.model.McItemCore;
 import org.opentestsystem.ap.common.model.ValidationResult;
 import org.opentestsystem.ap.irj.util.ReportUtil;
+
+import java.util.List;
 
 import static java.lang.String.valueOf;
 

--- a/src/main/java/org/opentestsystem/ap/irj/model/MiItemReport.java
+++ b/src/main/java/org/opentestsystem/ap/irj/model/MiItemReport.java
@@ -1,12 +1,12 @@
 package org.opentestsystem.ap.irj.model;
 
-import java.util.List;
-
 import org.opentestsystem.ap.common.model.MiItem;
 import org.opentestsystem.ap.common.model.MiItemCore;
 import org.opentestsystem.ap.common.model.Table;
 import org.opentestsystem.ap.common.model.ValidationResult;
 import org.opentestsystem.ap.irj.util.ReportUtil;
+
+import java.util.List;
 
 import static java.lang.String.valueOf;
 

--- a/src/main/java/org/opentestsystem/ap/irj/model/MsItemReport.java
+++ b/src/main/java/org/opentestsystem/ap/irj/model/MsItemReport.java
@@ -1,13 +1,13 @@
 package org.opentestsystem.ap.irj.model;
 
-import java.util.List;
-
 import lombok.Getter;
 import org.opentestsystem.ap.common.model.ItemOption;
 import org.opentestsystem.ap.common.model.MsItem;
 import org.opentestsystem.ap.common.model.MsItemCore;
 import org.opentestsystem.ap.common.model.ValidationResult;
 import org.opentestsystem.ap.irj.util.ReportUtil;
+
+import java.util.List;
 
 import static java.lang.String.valueOf;
 

--- a/src/main/java/org/opentestsystem/ap/irj/model/ReportConstants.java
+++ b/src/main/java/org/opentestsystem/ap/irj/model/ReportConstants.java
@@ -2,8 +2,10 @@ package org.opentestsystem.ap.irj.model;
 
 public interface ReportConstants {
 
-    interface Status {
+    String NO = "no";
+    String YES = "yes";
 
+    interface Status {
         String STATUS_SUCCESS = "";
         String STATUS_FAILED = "Failed";
         String STATUS_CREATING = "Creating";

--- a/src/main/java/org/opentestsystem/ap/irj/model/ReportConstants.java
+++ b/src/main/java/org/opentestsystem/ap/irj/model/ReportConstants.java
@@ -2,8 +2,8 @@ package org.opentestsystem.ap.irj.model;
 
 public interface ReportConstants {
 
-    String NO = "no";
-    String YES = "yes";
+    String NO = "No";
+    String YES = "Yes";
 
     interface Status {
         String STATUS_SUCCESS = "";

--- a/src/main/java/org/opentestsystem/ap/irj/model/ReportSummary.java
+++ b/src/main/java/org/opentestsystem/ap/irj/model/ReportSummary.java
@@ -1,11 +1,11 @@
 package org.opentestsystem.ap.irj.model;
 
+import lombok.Data;
+import lombok.Getter;
+
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-
-import lombok.Data;
-import lombok.Getter;
 
 import static java.util.stream.Collectors.toList;
 

--- a/src/main/java/org/opentestsystem/ap/irj/model/SaItemReport.java
+++ b/src/main/java/org/opentestsystem/ap/irj/model/SaItemReport.java
@@ -1,12 +1,12 @@
 package org.opentestsystem.ap.irj.model;
 
-import java.util.List;
-
 import lombok.Getter;
 import org.opentestsystem.ap.common.model.SaItem;
 import org.opentestsystem.ap.common.model.SaItemCore;
 import org.opentestsystem.ap.common.model.ValidationResult;
 import org.opentestsystem.ap.irj.util.ReportUtil;
+
+import java.util.List;
 
 public class SaItemReport extends AbstractAssessmentItemReport<SaItem> {
 

--- a/src/main/java/org/opentestsystem/ap/irj/model/StimulusReport.java
+++ b/src/main/java/org/opentestsystem/ap/irj/model/StimulusReport.java
@@ -1,13 +1,18 @@
 package org.opentestsystem.ap.irj.model;
 
-import java.util.List;
-
 import lombok.Getter;
+import org.opentestsystem.ap.common.model.ItemAudioResource;
 import org.opentestsystem.ap.common.model.ItemMetadata;
 import org.opentestsystem.ap.common.model.StimItem;
 import org.opentestsystem.ap.common.model.StimItemCore;
 import org.opentestsystem.ap.common.model.ValidationResult;
 import org.opentestsystem.ap.irj.util.ReportUtil;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+import static org.opentestsystem.ap.irj.util.ReportUtil.yesNo;
+import static org.opentestsystem.ap.irj.util.ReportUtil.yesNoUndetermined;
 
 public class StimulusReport extends AbstractItemReport<StimItem> {
 
@@ -34,6 +39,51 @@ public class StimulusReport extends AbstractItemReport<StimItem> {
         private Content(final StimItemCore core) {
             this.content = core.getEn().getContent();
         }
+    }
+
+
+    @Override
+    public String getAslRequired() {
+        return yesNoUndetermined(getItem().getAsl().getAslRequired());
+    }
+
+    @Override
+    public String getAslProvided() {
+        return yesNo(getItem().getAsl().isAslProvided());
+    }
+
+    @Override
+    public String getTranslationRequired() {
+        return yesNoUndetermined(getItem().getTranslations().getEsp().isRequired());
+    }
+
+    @Override
+    public String getTranslationProvided() {
+        return yesNo(getItem().getTranslations().getEsp().isProvided());
+    }
+
+    @Override
+    public String getAudioProductionFilesProvided() {
+        try {
+            final int numberOfResources = getItem().getAudio().getAudioResources().size();
+
+            final List<ItemAudioResource> resourcesWithProductionFiles = getItem().getAudio().getAudioResources().stream().
+                    filter(ItemAudioResource::isProductionFilesProvided).collect(toList());
+
+            return yesNo(numberOfResources == resourcesWithProductionFiles.size());
+        } catch (Exception e) {
+            return yesNo(false);
+        }
+    }
+
+    @Override
+    public String getCcProvided() {
+        return yesNo(getItem().getCc().isCcProvided());
+    }
+
+    @Override
+    public String getCcRequired() {
+        return yesNoUndetermined(getItem().getCc().getCcRequired());
     }
 
     @Override

--- a/src/main/java/org/opentestsystem/ap/irj/model/TiItemReport.java
+++ b/src/main/java/org/opentestsystem/ap/irj/model/TiItemReport.java
@@ -1,13 +1,13 @@
 package org.opentestsystem.ap.irj.model;
 
-import java.util.List;
-
 import lombok.Getter;
 import org.opentestsystem.ap.common.model.Table;
 import org.opentestsystem.ap.common.model.TiItem;
 import org.opentestsystem.ap.common.model.TiItemCore;
 import org.opentestsystem.ap.common.model.ValidationResult;
 import org.opentestsystem.ap.irj.util.ReportUtil;
+
+import java.util.List;
 
 import static java.lang.String.valueOf;
 import static org.apache.commons.lang3.StringUtils.EMPTY;

--- a/src/main/java/org/opentestsystem/ap/irj/model/TutItemReport.java
+++ b/src/main/java/org/opentestsystem/ap/irj/model/TutItemReport.java
@@ -1,12 +1,12 @@
 package org.opentestsystem.ap.irj.model;
 
-import java.util.List;
-
 import lombok.Getter;
 import org.opentestsystem.ap.common.model.TutItem;
 import org.opentestsystem.ap.common.model.TutItemCore;
 import org.opentestsystem.ap.common.model.ValidationResult;
 import org.opentestsystem.ap.irj.util.ReportUtil;
+
+import java.util.List;
 
 public class TutItemReport extends AbstractItemReport<TutItem> {
 
@@ -31,4 +31,5 @@ public class TutItemReport extends AbstractItemReport<TutItem> {
             this.content = core.getEn().getContent();
         }
     }
+
 }

--- a/src/main/java/org/opentestsystem/ap/irj/model/WerItemReport.java
+++ b/src/main/java/org/opentestsystem/ap/irj/model/WerItemReport.java
@@ -1,12 +1,12 @@
 package org.opentestsystem.ap.irj.model;
 
-import java.util.List;
-
 import lombok.Getter;
 import org.opentestsystem.ap.common.model.ValidationResult;
 import org.opentestsystem.ap.common.model.WerItem;
 import org.opentestsystem.ap.common.model.WerItemCore;
 import org.opentestsystem.ap.irj.util.ReportUtil;
+
+import java.util.List;
 
 public class WerItemReport extends AbstractAssessmentItemReport<WerItem> {
 

--- a/src/main/java/org/opentestsystem/ap/irj/repository/ReportRepository.java
+++ b/src/main/java/org/opentestsystem/ap/irj/repository/ReportRepository.java
@@ -1,8 +1,5 @@
 package org.opentestsystem.ap.irj.repository;
 
-import java.nio.file.Path;
-import java.util.List;
-
 import lombok.extern.slf4j.Slf4j;
 import org.gitlab4j.api.models.Project;
 import org.opentestsystem.ap.common.client.GitClient;
@@ -14,6 +11,9 @@ import org.opentestsystem.ap.common.model.ItemBankSystemUser;
 import org.opentestsystem.ap.common.repository.RepositoryDependencyProvider;
 import org.opentestsystem.ap.irj.util.ReportUtil;
 import org.springframework.stereotype.Component;
+
+import java.nio.file.Path;
+import java.util.List;
 
 import static org.opentestsystem.ap.common.repository.RepositoryUtil.generateLocalRepoPath;
 

--- a/src/main/java/org/opentestsystem/ap/irj/rest/ExceptionAdvice.java
+++ b/src/main/java/org/opentestsystem/ap/irj/rest/ExceptionAdvice.java
@@ -11,8 +11,6 @@
  */
 package org.opentestsystem.ap.irj.rest;
 
-import java.util.List;
-
 import lombok.extern.slf4j.Slf4j;
 import org.opentestsystem.ap.common.exception.ResourceNotFoundException;
 import org.opentestsystem.ap.common.exception.UnauthorizedException;
@@ -24,6 +22,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.List;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;

--- a/src/main/java/org/opentestsystem/ap/irj/rest/v1/ItemReportJobApi.java
+++ b/src/main/java/org/opentestsystem/ap/irj/rest/v1/ItemReportJobApi.java
@@ -15,9 +15,6 @@
  */
 package org.opentestsystem.ap.irj.rest.v1;
 
-import java.nio.file.Path;
-import java.util.List;
-
 import io.swagger.annotations.Api;
 import lombok.extern.slf4j.Slf4j;
 import org.opentestsystem.ap.irj.service.ItemReportManager;
@@ -27,6 +24,9 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.nio.file.Path;
+import java.util.List;
 
 /**
  *

--- a/src/main/java/org/opentestsystem/ap/irj/service/ItemReportManager.java
+++ b/src/main/java/org/opentestsystem/ap/irj/service/ItemReportManager.java
@@ -1,16 +1,5 @@
 package org.opentestsystem.ap.irj.service;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
-
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 import freemarker.template.TemplateExceptionHandler;
@@ -30,6 +19,17 @@ import org.opentestsystem.ap.irj.util.ReportUtil;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toList;
 import static org.opentestsystem.ap.irj.util.ReportUtil.generateReportFileName;

--- a/src/main/java/org/opentestsystem/ap/irj/service/ItemReportService.java
+++ b/src/main/java/org/opentestsystem/ap/irj/service/ItemReportService.java
@@ -1,15 +1,5 @@
 package org.opentestsystem.ap.irj.service;
 
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Date;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Predicate;
-
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -29,6 +19,16 @@ import org.opentestsystem.ap.irj.repository.ReportRepository;
 import org.opentestsystem.ap.irj.util.ReportUtil;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Predicate;
 
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toList;

--- a/src/main/java/org/opentestsystem/ap/irj/util/ReportUtil.java
+++ b/src/main/java/org/opentestsystem/ap/irj/util/ReportUtil.java
@@ -1,5 +1,46 @@
 package org.opentestsystem.ap.irj.util;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.opentestsystem.ap.common.exception.SystemException;
+import org.opentestsystem.ap.common.model.EbsrItem;
+import org.opentestsystem.ap.common.model.EqItem;
+import org.opentestsystem.ap.common.model.GiItem;
+import org.opentestsystem.ap.common.model.HtqoItem;
+import org.opentestsystem.ap.common.model.HtqsItem;
+import org.opentestsystem.ap.common.model.Item;
+import org.opentestsystem.ap.common.model.McItem;
+import org.opentestsystem.ap.common.model.MiItem;
+import org.opentestsystem.ap.common.model.MsItem;
+import org.opentestsystem.ap.common.model.SaItem;
+import org.opentestsystem.ap.common.model.StimItem;
+import org.opentestsystem.ap.common.model.Table;
+import org.opentestsystem.ap.common.model.TiItem;
+import org.opentestsystem.ap.common.model.TutItem;
+import org.opentestsystem.ap.common.model.ValidationResult;
+import org.opentestsystem.ap.common.model.WerItem;
+import org.opentestsystem.ap.irj.model.BaseItem;
+import org.opentestsystem.ap.irj.model.BaseItemReport;
+import org.opentestsystem.ap.irj.model.EbsrItemReport;
+import org.opentestsystem.ap.irj.model.EqItemReport;
+import org.opentestsystem.ap.irj.model.GiItemReport;
+import org.opentestsystem.ap.irj.model.HtqoItemReport;
+import org.opentestsystem.ap.irj.model.HtqsItemReport;
+import org.opentestsystem.ap.irj.model.ItemReport;
+import org.opentestsystem.ap.irj.model.LoadResult;
+import org.opentestsystem.ap.irj.model.McItemReport;
+import org.opentestsystem.ap.irj.model.MiItemReport;
+import org.opentestsystem.ap.irj.model.MsItemReport;
+import org.opentestsystem.ap.irj.model.SaItemReport;
+import org.opentestsystem.ap.irj.model.StimulusReport;
+import org.opentestsystem.ap.irj.model.TiItemReport;
+import org.opentestsystem.ap.irj.model.TutItemReport;
+import org.opentestsystem.ap.irj.model.WerItemReport;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -7,17 +48,11 @@ import java.nio.file.Path;
 import java.util.Date;
 import java.util.List;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.io.FileUtils;
-import org.opentestsystem.ap.common.exception.SystemException;
-import org.opentestsystem.ap.common.model.*;
-import org.opentestsystem.ap.irj.model.*;
-
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+import static org.opentestsystem.ap.common.model.ItemConstants.UNDETERMINED;
+import static org.opentestsystem.ap.irj.model.ReportConstants.NO;
+import static org.opentestsystem.ap.irj.model.ReportConstants.YES;
 
 @Slf4j
 public class ReportUtil {
@@ -27,6 +62,18 @@ public class ReportUtil {
     public static final String REPORT_SUMMARY_FILE_NAME_PATTERN = "item-report-%1$tF-%1$tT.log";
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    public static String yesNoUndetermined(final String value) {
+        return StringUtils.equalsIgnoreCase(UNDETERMINED, value) ? UNDETERMINED : yesNo(value);
+    }
+
+    public static String yesNo(final String value) {
+        return StringUtils.equalsIgnoreCase("true", value) ? YES : NO;
+    }
+
+    public static String yesNo(final boolean value) {
+        return value ? YES : NO;
+    }
 
     public static void deleteFolder(final Path folderToDelete) {
         try {


### PR DESCRIPTION
Fixed a few issues with the report.  We were not generating certain report fields because we hadn't implemented them at the time of writing the report job.

Instead of output true or false, the report outputs Yes or No.  This is more consistent with the values on the iat.

I dropped the threads from 25 to 10.  I'm confident this will reduce the number of errors we get in the report.  Not errors, but we are overloading GitLab with 25 threads and the report reflects that with 10 to 20 items always flagged as failed.  Dropping to 10 threads the failed count went down to three and those look to actually be corrupted or bad items in the item bank.  