### PR TITLE
IAT-2174: Items with only a single master branch are flagged as faili…

### DIFF
--- a/src/main/java/org/opentestsystem/ap/irj/service/ItemReportService.java
+++ b/src/main/java/org/opentestsystem/ap/irj/service/ItemReportService.java
@@ -4,6 +4,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.math.NumberUtils;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.api.errors.RefNotFoundException;
 import org.opentestsystem.ap.common.client.GitClient;
 import org.opentestsystem.ap.common.config.ItemBankProperties;
 import org.opentestsystem.ap.common.exception.SystemException;
@@ -25,6 +27,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -40,6 +43,8 @@ import static org.opentestsystem.ap.irj.model.ReportConstants.Status.STATUS_SUCC
 @Slf4j
 @Component
 public class ItemReportService {
+
+    private static final List<ValidationResult> EMPTY_VALIDATION_RESULTS = Collections.emptyList();
 
     private final ItemBankSystemUser systemUser;
 
@@ -130,33 +135,68 @@ public class ItemReportService {
     public List<String> findAllItemNames() {
         final List<String> ids = itemRepository.findAllItemNames();
 
-        final List<String> filteredIds = ids.stream().filter(NumberUtils::isDigits).collect(toList());
+        final List<String> filteredIds = ids.stream()
+            .filter(NumberUtils::isDigits)
+            .filter(id -> {
+                try {
+                    return Integer.parseInt(id) < 600000000;
+                } catch (Exception e) {
+                    return false;
+                }
+            })
+            .collect(toList());
         filteredIds.sort(comparing(Integer::valueOf));
 
         return filteredIds;
     }
 
     public LoadResult loadItem(final String itemId) {
+        return loadItemWithRetry(itemId, true);
+    }
+
+    public LoadResult loadItemWithRetry(final String itemId, final boolean retryGitAPIException) {
+        Item item;
         LoadResult result;
-        Item item = null;
         ReportError error = null;
         GitClient client = null;
-        List<ValidationResult> validationResults = null;
         try {
             client = itemRepository.openRepository(systemUser, itemId);
             item = client.readModelFile();
-            validationResults = client.readValidationFile();
-            result = new LoadResult(item, STATUS_SUCCESS, validationResults, error);
+            result = new LoadResult(item, STATUS_SUCCESS, EMPTY_VALIDATION_RESULTS, error);
         } catch (Exception e) {
             if (e.getCause() instanceof FileNotFoundException) {
                 result = handleFileNotFoundException(client, itemId);
+            } else if (e.getCause() instanceof GitAPIException) {
+                if (retryGitAPIException) {
+                    result = handleGitAPIException(client, itemId);
+                } else {
+                    error = new ReportError(itemId, ExceptionUtils.getRootCauseMessage(e));
+                    result = new LoadResult(new BaseItem(itemId), STATUS_FAILED, EMPTY_VALIDATION_RESULTS, error);
+                }
             } else {
                 error = new ReportError(itemId, ExceptionUtils.getRootCauseMessage(e));
-                result = new LoadResult(new BaseItem(itemId), STATUS_FAILED, validationResults, error);
+                result = new LoadResult(new BaseItem(itemId), STATUS_FAILED, EMPTY_VALIDATION_RESULTS, error);
             }
         }
 
         return result;
+    }
+
+    /**
+     * Assumes there is an issue with the local repository for the item, so it is deleted then cloned from the remote
+     * origin.
+     *
+     * @param client The git client pointing to the item.
+     * @param itemId The item.
+     * @return The results of loading the item from the create branch.
+     */
+    private LoadResult handleGitAPIException(final GitClient client, final String itemId) {
+        try {
+            client.deleteLocalRepo();
+            client.cloneRemoteRepository();
+        } catch (Exception e) {
+        }
+        return loadItemWithRetry(itemId, false);
     }
 
     /**
@@ -170,19 +210,17 @@ public class ItemReportService {
         LoadResult result;
         Item item = null;
         ReportError error = null;
-        List<ValidationResult> validationResults = null;
         try {
             final String branch = itemRepository.findBranchBySection(itemId, SECTION_CREATE);
             client.checkoutBranch(branch);
             client.pullLatest();
 
             item = client.readModelFile();
-            validationResults = client.readValidationFile();
 
-            result = new LoadResult(item, STATUS_CREATING, validationResults, error);
+            result = new LoadResult(item, STATUS_CREATING, EMPTY_VALIDATION_RESULTS, error);
         } catch (Exception e) {
             error = new ReportError(itemId, ExceptionUtils.getRootCauseMessage(e));
-            result = new LoadResult(item, STATUS_FAILED, validationResults, error);
+            result = new LoadResult(item, STATUS_FAILED, EMPTY_VALIDATION_RESULTS, error);
         }
         return result;
     }


### PR DESCRIPTION
…ng within item report due to being in a state of MERGE.  The issue happens because the report job clones to the same spot which is different than ims that clones items to random locations.  Since the report job already has the item on disk is pulls the latest from GitLab which can and does put the master branch in MERGE status.  The next time the job runs it gets the error reported.

The fix is when this error is received to delete the item locally and pull it fresh from GitLab.  

Another quick fix was ignoring glossary.  The report is piling up glossary errors because there is no item.json.  This will greatly reduce the noise in the report.